### PR TITLE
refactor: remove 11ty from snowpack config

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -7,13 +7,6 @@ module.exports = {
   plugins: [
     '@snowpack/plugin-postcss',
     '@jadex/snowpack-plugin-tailwindcss-jit',
-    [
-      '@snowpack/plugin-run-script',
-      {
-        cmd: 'eleventy',
-        watch: '$1 --watch',
-      },
-    ],
   ],
   packageOptions: {
     NODE_ENV: true,


### PR DESCRIPTION
At the moment 11ty is run via scripts in the package.json.
